### PR TITLE
Bug fixes for dsl2ml

### DIFF
--- a/src/dsl2ml.js
+++ b/src/dsl2ml.js
@@ -1578,53 +1578,14 @@ function dsl2ml(dslStr, problem, _debug) {
 function ArrayBufferTransferPoly(source, length) {
   // c/p https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer
 
-  source = Object(source);
-  var dest = new ArrayBuffer(length);
-  if (!(source instanceof ArrayBuffer) || !(dest instanceof ArrayBuffer)) {
-    throw new TypeError('Source and destination must be ArrayBuffer instances');
-  }
-  if (dest.byteLength >= source.byteLength) {
-    var nextOffset = 0;
-    var leftBytes = source.byteLength;
-    var wordSizes = [8, 4, 2, 1];
-    wordSizes.forEach(function(_wordSize_) {
-      if (leftBytes >= _wordSize_) {
-        var done = transferWith(_wordSize_, source, dest, nextOffset, leftBytes);
-        nextOffset = done.nextOffset;
-        leftBytes = done.leftBytes;
-      }
-    });
-  }
-  return dest;
-  function transferWith(wordSize, source, dest, nextOffset, leftBytes) {
-    var ViewClass = Uint8Array;
-    switch (wordSize) {
-      case 8:
-        ViewClass = Float64Array;
-        break;
-      case 4:
-        ViewClass = Float32Array;
-        break;
-      case 2:
-        ViewClass = Uint16Array;
-        break;
-      case 1:
-        ViewClass = Uint8Array;
-        break;
-      default:
-        ViewClass = Uint8Array;
-        break;
-    }
-    var view_source = new ViewClass(source, nextOffset, Math.trunc(leftBytes / wordSize));
-    var view_dest = new ViewClass(dest, nextOffset, Math.trunc(leftBytes / wordSize));
-    for (var i = 0; i < view_dest.length; i++) {
-      view_dest[i] = view_source[i];
-    }
-    return {
-      nextOffset: view_source.byteOffset + view_source.byteLength,
-      leftBytes: source.byteLength - (view_source.byteOffset + view_source.byteLength),
-    };
-  }
+  if (!(source instanceof ArrayBuffer))
+    throw new TypeError('Source must be an instance of ArrayBuffer');
+  if (length <= source.byteLength)
+    return source.slice(0, length);
+  var sourceView = new Uint8Array(source),
+    destView = new Uint8Array(new ArrayBuffer(length));
+  destView.set(sourceView);
+  return destView.buffer;
 }
 
 // BODY_STOP


### PR DESCRIPTION
I tracked down the reason why FDQ in Firefox doesn't work in certain cases where it does in Chrome, such as for puzzles 2 and 3 in the [sudoku example](https://pvdz.github.io/fdq/examples/sudoku.html). The reason was a bug in [the `ArrayBufferTransferPoly` polyfill in `dsl2ml.js`](https://github.com/pvdz/fdp/blob/master/src/dsl2ml.js#L1579-L1627), which in certain cases clobbers data in Firefox.

The [first commit](https://github.com/joshtch/fdp/commit/929f7c232799dcf7c0b4652bd62fb23a87a85a1b) fixes that issue by copy & pasting the fixed implementation from the [same place](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer#Polyfill) you [copied](https://github.com/pvdz/fdp/blob/master/src/dsl2ml.js#L1579) the original. It looks like someone else noticed the bug in the MDN implementation and published the fix sometime after you grabbed it.

While I was debugging that issue, I noticed [`compileJump`](https://github.com/pvdz/fdp/blob/master/src/dsl2ml.js#L1416-L1454) doesn't need to call `grow` [here](https://github.com/pvdz/fdp/blob/master/src/dsl2ml.js#L1442) when the jump doesn't go past the end of `mlBuffer`. And in fact, [this `compileJump` invocation](https://github.com/pvdz/fdp/blob/master/src/dsl2ml.js#L175) (and supporting comments) doesn't(/don't) make sense if `compileJump` always allocates more memory unconditionally, as it currently does. 

The [second commit](https://github.com/joshtch/fdp/commit/4747dc183ad3341443b35e84c868cf7f347e31d7) adds a check before `compileJump` calls `grow` so it only calls `grow` when necessary (and when it does call `grow`, it only over-provisions by 10%, instead of 100% like it does now).