### PR TITLE
Fix FDP to handle multiple solutions from FDO

### DIFF
--- a/src/fdp.js
+++ b/src/fdp.js
@@ -211,6 +211,8 @@ function _preSolver(dsl, solver, options, solveOptions) {
 
   if (fdSolution && typeof fdSolution !== 'string') {
     term.error('<solved after fdq>');
+    if (Array.isArray(fdSolution))
+      return fdSolution.map(sol => createSolution(problem, sol, options, solveOptions.max || Infinity));
     return createSolution(problem, fdSolution, options, solveOptions.max || Infinity);
   }
 


### PR DESCRIPTION
When FDO is given the option `max`, it outputs up to `max` solutions as an array. This fix has FDP map `createSolution` over each solution in the array, rather than try to apply `createSolution` on the entire array, which results in malformed output.